### PR TITLE
Fix firestore id mismatch for cash flows

### DIFF
--- a/lib/models/cash_flow.dart
+++ b/lib/models/cash_flow.dart
@@ -21,12 +21,13 @@ class CashFlow {
   final TransactionType transactionType;
 
   CashFlow({
+    String? id,
     required this.title,
     required this.amount,
     required this.date,
     required this.hebrewDate,
     required this.transactionType,
-  }) : id = uuid.v4();
+  }) : id = id ?? uuid.v4();
 
   String get formattedDate {
     return formatter.format(date);

--- a/lib/providers/cash_flow_provider.dart
+++ b/lib/providers/cash_flow_provider.dart
@@ -25,13 +25,14 @@ class CashFlowProvider extends ChangeNotifier {
           .then((snapshot) {
         final cashFlows = snapshot.docs
             .map((doc) => CashFlow(
-          title: doc['title'],
-          amount: doc['amount'],
-          date: DateTime.fromMillisecondsSinceEpoch(doc['date']),
-          hebrewDate: JewishDate.fromDateTime(
-              DateTime.fromMillisecondsSinceEpoch(doc['date'])),
-          transactionType: TransactionType.values[doc['transactionType']],
-        ))
+                  id: doc.data().containsKey('id') ? doc['id'] : doc.id,
+                  title: doc['title'],
+                  amount: doc['amount'],
+                  date: DateTime.fromMillisecondsSinceEpoch(doc['date']),
+                  hebrewDate: JewishDate.fromDateTime(
+                      DateTime.fromMillisecondsSinceEpoch(doc['date'])),
+                  transactionType: TransactionType.values[doc['transactionType']],
+                ))
             .toList();
         _cashFlows.addAll(cashFlows);
         notifyListeners();
@@ -98,7 +99,8 @@ class CashFlowProvider extends ChangeNotifier {
           .collection('users')
           .doc(user.uid)
           .collection('cashFlows')
-          .add(expense.toMap());
+          .doc(expense.id)
+          .set(expense.toMap());
     }
   }
 


### PR DESCRIPTION
## Summary
- allow passing an id when creating `CashFlow`
- keep firestore document id consistent when adding and loading cash flows

## Testing
- `flutter analyze` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6848d7cee5cc8331a841cec765dd229a