### PR TITLE
Add snackbar validation for new cash flow

### DIFF
--- a/lib/widgets/new_cash_flow.dart
+++ b/lib/widgets/new_cash_flow.dart
@@ -81,7 +81,11 @@ class _NewCashFlowState extends State<NewCashFlow> {
     final enteredAmount = double.tryParse(_amountController.text);
     final amountIsValid = enteredAmount != null && enteredAmount > 0;
     if (!amountIsValid || _selectedDate == null) {
-      // Show error
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text('Please enter a valid amount and date.'),
+        ),
+      );
       return;
     }
 


### PR DESCRIPTION
## Summary
- show a `SnackBar` when attempting to submit cash flow with an invalid date or amount

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687957969cb4833191ea5d03988daf1c