### PR TITLE
Redesign month/year selector with swipe navigation

### DIFF
--- a/lib/providers/cash_flow_provider.dart
+++ b/lib/providers/cash_flow_provider.dart
@@ -91,6 +91,38 @@ class CashFlowProvider extends ChangeNotifier {
     return months;
   }
 
+  List<String> getMonthsForYear(String? year, bool isHebrew) {
+    if (isHebrew) {
+      final fallbackYear = JewishDate.fromDateTime(DateTime.now())
+          .getJewishYear()
+          .toString();
+      final parsedYear = int.tryParse(year ?? fallbackYear) ??
+          JewishDate.fromDateTime(DateTime.now()).getJewishYear();
+
+      final jewishDate = JewishDate();
+      jewishDate.setJewishDate(parsedYear, JewishDate.TISHREI, 1);
+      final lastMonth =
+          jewishDate.isJewishLeapYear() ? JewishDate.ADAR_II : JewishDate.ADAR;
+
+      final months = <String>[];
+      for (int month = JewishDate.TISHREI; month <= lastMonth; month++) {
+        final currentMonth = JewishDate();
+        currentMonth.setJewishDate(parsedYear, month, 1);
+        months.add(hebrewDateFormatter.formatMonth(currentMonth));
+      }
+      return months;
+    } else {
+      final fallbackYear = DateFormat.y().format(DateTime.now());
+      final parsedYear = int.tryParse(year ?? fallbackYear) ?? DateTime.now().year;
+      return List.generate(
+        12,
+        (index) => DateFormat.MMMM().format(
+          DateTime(parsedYear, index + 1, 1),
+        ),
+      );
+    }
+  }
+
   List<String> getAvailableYears(TransactionType? transactionType, bool isHebrew) {
     final years = _cashFlows.where((cashFlow) {
       return transactionType == null ||

--- a/lib/widgets/expenses_list.dart
+++ b/lib/widgets/expenses_list.dart
@@ -278,13 +278,6 @@ class _ExpensesListState extends State<ExpensesList> {
                           borderRadius: BorderRadius.circular(12),
                         ),
                       ),
-                      const SizedBox(height: 16),
-                      Text(
-                        'Select month',
-                        style: textTheme.titleLarge?.copyWith(
-                          fontWeight: FontWeight.w700,
-                        ),
-                      ),
                       const SizedBox(height: 12),
                       Wrap(
                         spacing: 12,
@@ -444,35 +437,6 @@ class _ExpensesListState extends State<ExpensesList> {
                       const EdgeInsets.symmetric(horizontal: 20, vertical: 16),
                   child: Column(
                     children: [
-                      Wrap(
-                        spacing: 12,
-                        alignment: WrapAlignment.center,
-                        children: [
-                          ChoiceChip(
-                            label: const Text('Gregorian'),
-                            selected: !_isHebrew,
-                            onSelected: (value) {
-                              if (!value || !_isHebrew) return;
-                              setState(() {
-                                _isHebrew = false;
-                                _syncHebrewFromGregorian();
-                              });
-                            },
-                          ),
-                          ChoiceChip(
-                            label: const Text('Hebrew'),
-                            selected: _isHebrew,
-                            onSelected: (value) {
-                              if (!value || _isHebrew) return;
-                              setState(() {
-                                _isHebrew = true;
-                                _syncGregorianFromHebrew();
-                              });
-                            },
-                          ),
-                        ],
-                      ),
-                      const SizedBox(height: 20),
                       Row(
                         mainAxisAlignment: MainAxisAlignment.center,
                         children: [
@@ -530,37 +494,6 @@ class _ExpensesListState extends State<ExpensesList> {
                         ],
                       ),
                       const SizedBox(height: 16),
-                      Container(
-                        padding: const EdgeInsets.symmetric(
-                            horizontal: 16, vertical: 12),
-                        decoration: BoxDecoration(
-                          color: Theme.of(context)
-                              .colorScheme
-                              .surfaceVariant
-                              .withOpacity(0.6),
-                          borderRadius: BorderRadius.circular(18),
-                        ),
-                        child: Row(
-                          mainAxisAlignment: MainAxisAlignment.center,
-                          mainAxisSize: MainAxisSize.min,
-                          children: [
-                            Icon(
-                              Icons.swipe,
-                              size: 18,
-                              color: Theme.of(context).colorScheme.primary,
-                            ),
-                            const SizedBox(width: 8),
-                            Flexible(
-                              child: Text(
-                                'Swipe left or right anywhere to change the month',
-                                style:
-                                    Theme.of(context).textTheme.bodySmall,
-                                textAlign: TextAlign.center,
-                              ),
-                            ),
-                          ],
-                        ),
-                      ),
                     ],
                   ),
                 ),

--- a/lib/widgets/expenses_list.dart
+++ b/lib/widgets/expenses_list.dart
@@ -1,7 +1,9 @@
 import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+import 'package:kosher_dart/kosher_dart.dart';
 import 'package:maaserTracker/widgets/expenses_item.dart';
 import 'package:provider/provider.dart';
-import 'package:intl/intl.dart';
+
 import '../models/transaction_type.dart';
 import '../providers/cash_flow_provider.dart';
 import 'maaser_drawer.dart';
@@ -19,44 +21,91 @@ class _ExpensesListState extends State<ExpensesList> {
   String? _selectedMonth;
   String? _selectedYear;
   bool _isHebrew = false;
-  List<String> availableYears = [];
-  List<String> availableMonths = [];
+  late PageController _pageController;
 
   @override
   void initState() {
     super.initState();
-    _selectedMonth = 'Entire Year';
-    _selectedYear = DateFormat.y().format(DateTime.now());
+    final now = DateTime.now();
+    _selectedMonth = DateFormat.MMMM().format(now);
+    _selectedYear = DateFormat.y().format(now);
+    _pageController = PageController(
+      initialPage: now.month - 1,
+      viewportFraction: 0.65,
+    );
+  }
+
+  @override
+  void dispose() {
+    _pageController.dispose();
+    super.dispose();
   }
 
   @override
   Widget build(BuildContext context) {
     return Consumer<CashFlowProvider>(
       builder: (context, cashFlowProvider, child) {
-        availableYears = cashFlowProvider.getAvailableYears(widget.transactionType, _isHebrew);
+        final formatter = cashFlowProvider.hebrewDateFormatter;
 
-        //if available years is empty, add the current year to the set
+        var availableYears =
+            cashFlowProvider.getAvailableYears(widget.transactionType, _isHebrew);
         if (availableYears.isEmpty) {
-          availableYears.add(DateFormat.y().format(DateTime.now()));
-        } else if (!availableYears.contains(_selectedYear)) {
-          // If selected year is not available, select the most recent year to the present
+          final fallbackYear = _isHebrew
+              ? JewishDate.fromDateTime(DateTime.now())
+                  .getJewishYear()
+                  .toString()
+              : DateFormat.y().format(DateTime.now());
+          availableYears = [fallbackYear];
+        } else {
+          availableYears = availableYears.reversed.toList();
+        }
+
+        if (_selectedYear == null || !availableYears.contains(_selectedYear)) {
           _selectedYear = availableYears.first;
         }
 
+        final monthsWithEntries = cashFlowProvider
+            .getAvailableMonths(widget.transactionType, _selectedYear, _isHebrew)
+            .toSet();
+        final allMonths = cashFlowProvider.getMonthsForYear(
+          _selectedYear,
+          _isHebrew,
+        );
 
-        availableMonths = cashFlowProvider.getAvailableMonths(widget.transactionType, _selectedYear, _isHebrew);
-
-        // Ensure the selected month exists for the newly selected year
-        if (_selectedMonth != null &&
-            _selectedMonth != 'Entire Year' &&
-            !availableMonths.contains(_selectedMonth)) {
-          _selectedMonth = 'Entire Year';
+        if (allMonths.isNotEmpty) {
+          if (_selectedMonth == null || !allMonths.contains(_selectedMonth)) {
+            final currentMonth = _isHebrew
+                ? formatter
+                    .formatMonth(JewishDate.fromDateTime(DateTime.now()))
+                : DateFormat.MMMM().format(DateTime.now());
+            _selectedMonth =
+                allMonths.contains(currentMonth) ? currentMonth : allMonths.first;
+          }
         }
 
+        final currentMonthIndex = _selectedMonth != null
+            ? allMonths.indexOf(_selectedMonth!)
+            : 0;
+
+        final controllerPage = _pageController.hasClients
+            ? _pageController.page?.round()
+            : _pageController.initialPage;
+        if (currentMonthIndex >= 0 && controllerPage != currentMonthIndex) {
+          WidgetsBinding.instance.addPostFrameCallback((_) {
+            if (!mounted) return;
+            if (_pageController.hasClients) {
+              _pageController.animateToPage(
+                currentMonthIndex,
+                duration: const Duration(milliseconds: 220),
+                curve: Curves.easeInOut,
+              );
+            }
+          });
+        }
 
         final filteredExpenses = cashFlowProvider.getFilteredCashFlows(
           transactionType: widget.transactionType,
-          month: _selectedMonth == 'Entire Year' ? null : _selectedMonth,
+          month: _selectedMonth,
           year: _selectedYear,
           isHebrew: _isHebrew,
         );
@@ -86,65 +135,166 @@ class _ExpensesListState extends State<ExpensesList> {
           ),
           body: Column(
             children: [
-              Row(
-                mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-                children: [
-                  DropdownButton<String>(
-                    value: _selectedMonth,
-                    items: ['Entire Year', ...availableMonths].map((month) {
-                      return DropdownMenuItem(
-                        value: month,
-                        child: Text(month),
-                      );
-                    }).toList(),
-                    onChanged: (value) {
-                      setState(() {
-                        _selectedMonth = value;
-                      });
-                    },
-                  ),
-                  DropdownButton<String>(
-                    value: _selectedYear,
-                    items: availableYears.map((year) {
-                      return DropdownMenuItem(
-                        value: year,
-                        child: Text(year),
-                      );
-                    }).toList(),
-                    onChanged: (value) {
-                      setState(() {
-                        _selectedYear = value;
-                        // Update available months for the new year
-                        availableMonths = cashFlowProvider.getAvailableMonths(
-                            widget.transactionType, _selectedYear, _isHebrew);
-
-                        // Reset the selected month if it's no longer available
-                        if (_selectedMonth != null &&
-                            _selectedMonth != 'Entire Year' &&
-                            !availableMonths.contains(_selectedMonth)) {
-                          _selectedMonth = 'Entire Year';
-                        }
-                      });
-                    },
-                  ),
-                  Switch(
-                    value: _isHebrew,
-                    onChanged: (value) {
-                      setState(() {
-                        _isHebrew = value;
-                        availableYears = cashFlowProvider.getAvailableYears(widget.transactionType, _isHebrew);
-                        _selectedYear = availableYears.first;
-
-                        availableMonths = cashFlowProvider.getAvailableMonths(widget.transactionType, _selectedYear, _isHebrew);
-                        _selectedMonth = 'Entire Year';
-
-                      });
-                    },
-                    activeColor: Colors.blue,
-                    inactiveThumbColor: Colors.grey,
-                    inactiveTrackColor: Colors.grey[300],
-                  ),
-                ],
+              Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Row(
+                      children: [
+                        ToggleButtons(
+                          borderRadius: BorderRadius.circular(20),
+                          isSelected: [!_isHebrew, _isHebrew],
+                          onPressed: (index) {
+                            if ((index == 1) != _isHebrew) {
+                              setState(() {
+                                _isHebrew = index == 1;
+                                if (_isHebrew) {
+                                  final currentHebrewDate =
+                                      JewishDate.fromDateTime(DateTime.now());
+                                  _selectedYear =
+                                      currentHebrewDate.getJewishYear().toString();
+                                  _selectedMonth =
+                                      formatter.formatMonth(currentHebrewDate);
+                                } else {
+                                  final now = DateTime.now();
+                                  _selectedYear = DateFormat.y().format(now);
+                                  _selectedMonth =
+                                      DateFormat.MMMM().format(now);
+                                }
+                              });
+                            }
+                          },
+                          constraints: const BoxConstraints(minHeight: 36, minWidth: 110),
+                          children: const [
+                            Padding(
+                              padding: EdgeInsets.symmetric(horizontal: 8.0),
+                              child: Text('Gregorian'),
+                            ),
+                            Padding(
+                              padding: EdgeInsets.symmetric(horizontal: 8.0),
+                              child: Text('Hebrew'),
+                            ),
+                          ],
+                        ),
+                        const SizedBox(width: 16),
+                        Expanded(
+                          child: SingleChildScrollView(
+                            scrollDirection: Axis.horizontal,
+                            child: Row(
+                              children: availableYears
+                                  .map(
+                                    (year) => Padding(
+                                      padding:
+                                          const EdgeInsets.symmetric(horizontal: 4),
+                                      child: ChoiceChip(
+                                        label: Text(year),
+                                        selected: year == _selectedYear,
+                                        onSelected: (_) {
+                                          setState(() {
+                                            _selectedYear = year;
+                                          });
+                                        },
+                                      ),
+                                    ),
+                                  )
+                                  .toList(),
+                            ),
+                          ),
+                        ),
+                      ],
+                    ),
+                    const SizedBox(height: 16),
+                    Row(
+                      children: [
+                        IconButton(
+                          icon: const Icon(Icons.chevron_left),
+                          onPressed: currentMonthIndex > 0
+                              ? () {
+                                  final previousIndex = currentMonthIndex - 1;
+                                  _pageController.animateToPage(
+                                    previousIndex,
+                                    duration: const Duration(milliseconds: 220),
+                                    curve: Curves.easeInOut,
+                                  );
+                                  setState(() {
+                                    _selectedMonth = allMonths[previousIndex];
+                                  });
+                                }
+                              : null,
+                        ),
+                        Expanded(
+                          child: SizedBox(
+                            height: 100,
+                            child: PageView.builder(
+                              controller: _pageController,
+                              onPageChanged: (index) {
+                                if (index >= 0 && index < allMonths.length) {
+                                  setState(() {
+                                    _selectedMonth = allMonths[index];
+                                  });
+                                }
+                              },
+                              itemCount: allMonths.length,
+                              itemBuilder: (context, index) {
+                                final monthName = allMonths[index];
+                                final hasEntries = monthsWithEntries.contains(monthName);
+                                final isSelected = index == currentMonthIndex;
+                                return _MonthSelectionCard(
+                                  label: monthName,
+                                  hasEntries: hasEntries,
+                                  isSelected: isSelected,
+                                );
+                              },
+                            ),
+                          ),
+                        ),
+                        IconButton(
+                          icon: const Icon(Icons.chevron_right),
+                          onPressed: currentMonthIndex < allMonths.length - 1
+                              ? () {
+                                  final nextIndex = currentMonthIndex + 1;
+                                  _pageController.animateToPage(
+                                    nextIndex,
+                                    duration: const Duration(milliseconds: 220),
+                                    curve: Curves.easeInOut,
+                                  );
+                                  setState(() {
+                                    _selectedMonth = allMonths[nextIndex];
+                                  });
+                                }
+                              : null,
+                        ),
+                      ],
+                    ),
+                    const SizedBox(height: 8),
+                    Row(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      children: [
+                        Icon(
+                          Icons.swipe,
+                          size: 18,
+                          color: Theme.of(context).colorScheme.primary,
+                        ),
+                        const SizedBox(width: 8),
+                        Text(
+                          'Swipe left or right to change the month',
+                          style: Theme.of(context).textTheme.bodySmall,
+                        ),
+                      ],
+                    ),
+                    const SizedBox(height: 12),
+                    Text(
+                      _selectedMonth != null && _selectedYear != null
+                          ? 'Showing $_selectedMonth $_selectedYear ${_isHebrew ? '(Hebrew calendar)' : '(Gregorian calendar)'}'
+                          : '',
+                      style: Theme.of(context)
+                          .textTheme
+                          .bodyMedium
+                          ?.copyWith(fontWeight: FontWeight.w600),
+                    ),
+                  ],
+                ),
               ),
               Expanded(
                 child: ListView.builder(
@@ -161,6 +311,89 @@ class _ExpensesListState extends State<ExpensesList> {
           ),
         );
       },
+    );
+  }
+}
+
+class _MonthSelectionCard extends StatelessWidget {
+  const _MonthSelectionCard({
+    required this.label,
+    required this.hasEntries,
+    required this.isSelected,
+  });
+
+  final String label;
+  final bool hasEntries;
+  final bool isSelected;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+
+    final backgroundColor = isSelected
+        ? colorScheme.primaryContainer
+        : colorScheme.surfaceVariant;
+    final borderColor = isSelected
+        ? colorScheme.primary
+        : colorScheme.outline;
+    final labelStyle = theme.textTheme.titleMedium?.copyWith(
+      fontWeight: FontWeight.w600,
+      color: isSelected ? colorScheme.onPrimaryContainer : colorScheme.onSurfaceVariant,
+    );
+    final defaultStatusColor =
+        theme.textTheme.bodySmall?.color ?? colorScheme.onSurfaceVariant;
+    final statusStyle = theme.textTheme.bodySmall?.copyWith(
+      color: isSelected
+          ? colorScheme.onPrimaryContainer.withOpacity(0.8)
+          : defaultStatusColor.withOpacity(0.7),
+    );
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 8.0, vertical: 12),
+      child: AnimatedContainer(
+        duration: const Duration(milliseconds: 200),
+        decoration: BoxDecoration(
+          color: backgroundColor,
+          borderRadius: BorderRadius.circular(18),
+          border: Border.all(color: borderColor, width: isSelected ? 2 : 1),
+        ),
+        child: Stack(
+          children: [
+            Positioned(
+              top: 10,
+              right: 12,
+              child: AnimatedContainer(
+                duration: const Duration(milliseconds: 200),
+                width: 10,
+                height: 10,
+                decoration: BoxDecoration(
+                  shape: BoxShape.circle,
+                  color:
+                      hasEntries ? colorScheme.secondary : colorScheme.outline,
+                ),
+              ),
+            ),
+            Center(
+              child: Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 16),
+                child: Column(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    Text(label, style: labelStyle, textAlign: TextAlign.center),
+                    const SizedBox(height: 6),
+                    Text(
+                      hasEntries ? 'Entries available' : 'No entries yet',
+                      style: statusStyle,
+                      textAlign: TextAlign.center,
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
     );
   }
 }

--- a/windows/flutter/CMakeLists.txt
+++ b/windows/flutter/CMakeLists.txt
@@ -10,6 +10,11 @@ include(${EPHEMERAL_DIR}/generated_config.cmake)
 # https://github.com/flutter/flutter/issues/57146.
 set(WRAPPER_ROOT "${EPHEMERAL_DIR}/cpp_client_wrapper")
 
+# Set fallback configurations for older versions of the flutter tool.
+if (NOT DEFINED FLUTTER_TARGET_PLATFORM)
+  set(FLUTTER_TARGET_PLATFORM "windows-x64")
+endif()
+
 # === Flutter Library ===
 set(FLUTTER_LIBRARY "${EPHEMERAL_DIR}/flutter_windows.dll")
 


### PR DESCRIPTION
## Summary
- replace the month/year dropdowns with a swipeable selector that highlights months containing entries and adds a toggle between Gregorian and Hebrew calendars
- add a provider helper to build complete month lists for Gregorian and Hebrew years so that all months remain selectable

## Testing
- not run (Flutter SDK unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_6907a5af0aa483319d6f49318c075f29